### PR TITLE
Fix for new macro system.

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -106,7 +106,15 @@
   (syntax-parse stx 
     [(_ base-cls:id (i-face:id ...) elem:data-class-element ...) 
      (with-syntax ([cls-id (generate-temporary #'class-id-)]
-                   [m-data (generate-temporary #'metadata-)])
+                   [m-data (generate-temporary #'metadata-)]
+                   [ctxt ctxt-id]
+                   [set-auto-pkey! set-auto-pkey!-id]
+                   [set-pkey! set-pkey!-id]
+                   [set-tbl-nm-m-data! set-tbl-nm-m-data!-id]
+                   [jn-fld jn-fld-id]
+                   [jn-cls jn-cls-id]
+                   [con con-id]
+                   [dbsys-type dbsys-type-id])
        #'(let* ([ctxt null]
                 [m-data (new data-class-metadata%)]
                 [set-tbl-nm-m-data! (λ (tbl-nm extern-nm) (set-field! table-name m-data tbl-nm) 
@@ -157,6 +165,8 @@
 (define-syntax (get-join stx)
   (syntax-case stx ()
     ([_ jn-fld obj con] 
+     (with-syntax ([jn-def jn-def-id]
+                   [jn-cls jn-cls-id])
      #'(begin
          (when (eq? (get-field jn-fld obj) #f)
            (let* ([jn-def (get-join-definition jn-fld (object-class obj))]     
@@ -167,7 +177,7 @@
              (when (and (equal? (join-definition-cardinality jn-def) 'one-to-one) 
                         (> (length (get-field jn-fld obj)) 0))
                (set-field! jn-fld obj (first (get-field jn-fld obj))))))
-         (get-field jn-fld obj)))))
+         (get-field jn-fld obj))))))
 
 
 ;;; DATA CLASS GENERATION
@@ -325,7 +335,9 @@
     [(_ con:id cls:id (~optional (~seq #:print? prnt:expr)) (~optional (~seq #:prepare? prep:expr)) 
         join:join-expr ... where:where-expr rest:expr ...)
      (with-syntax ([prnt? (or (attribute prnt) #'#f)]
-                   [prep? (not (or (attribute prep) #'#f))])
+                   [prep? (not (or (attribute prep) #'#f))]
+                   [ctxt ctxt-id]
+                   [dbsys-type dbsys-type-id])
        #'(let* ([ctxt (list cls)]
                 [dbsys-type (dbsystem-type con)]
                 [sql (make-select-statement con cls #:print? prnt? #:prepare? prep? 
@@ -347,7 +359,9 @@
     [(_ con:id cls:id (~optional (~seq #:print? prnt:expr)) (~optional (~seq #:prepare? prep:expr))
         join:join-expr ... where:where-expr rest:expr ...)
      (with-syntax ([prnt? (or (attribute prnt) #'#f)]
-                   [prep? (not (or (attribute prep) #'#f))])
+                   [prep? (not (or (attribute prep) #'#f))]
+                   [ctxt ctxt-id]
+                   [dbsys-type dbsys-type-id])
        #'(let* ([ctxt (list cls)]
                 [dbsys-type (dbsystem-type con)]
                 [sql (make-select-statement con cls #:print? prnt? #:prepare? prep? 

--- a/stxclass.rkt
+++ b/stxclass.rkt
@@ -41,6 +41,16 @@
                     (get-field id obj))
 |#
 
+(define ctxt-id #'ctxt)
+(define con-id #'con)
+(define dbsys-type-id #'dbsys-type)
+(define jn-fld-id #'jn-fld)
+(define jn-def-id #'jn-def)
+(define jn-cls-id #'jn-cls)
+(define set-tbl-nm-m-data!-id #'set-tbl-nm-m-data!)
+(define set-pkey!-id #'set-pkey!)
+(define set-auto-pkey!-id #'set-auto-pkey!)
+
 ;;; Parse an RQL expression.
 (define-syntax-class rql-expr
   #:description "rql expression"


### PR DESCRIPTION
The problem here was the next-to-last bullet in this section: 
http://www.cs.utah.edu/~mflatt/scope-sets-5/implementation.html#%28part._compat%29

The fix is to use the _same_ id for both the binding and the reference, which
is accomplished by defining them once-and-for-all in the stxclass.rkt file.